### PR TITLE
Refactor CORS configuration to improve allowed origins structure and …

### DIFF
--- a/config/cors.php
+++ b/config/cors.php
@@ -20,8 +20,15 @@ return [
 
     'allowed_methods' => ['*'],
 
-    // 'allowed_origins' => [env('FRONTEND_URL', 'http://localhost:3000')],
-    'allowed_origins' => ['http://localhost:3000', 'http://127.0.0.1:3000', 'http://localhost:5173', 'http://127.0.0.1:5173'],
+    'allowed_origins' => [
+        // Local development
+        'http://localhost:3000',
+        'http://127.0.0.1:3000',
+        'http://localhost:5173',
+        'http://127.0.0.1:5173',
+        // Production - Add your Vercel domain
+        'https://todo-list-livid-six.vercel.app'
+    ],
 
 
     'allowed_origins_patterns' => [],


### PR DESCRIPTION
This pull request updates the CORS configuration to support both local development and production environments. The most important change is the addition of the production Vercel domain to the list of allowed origins.

CORS configuration updates:

* Added `https://todo-list-livid-six.vercel.app` to the `allowed_origins` array in `config/cors.php` to allow requests from the production frontend hosted on Vercel.
* Improved documentation within the array to clarify which origins are for local development and which are for production.…ensure supports_credentials is set to false