### PR TITLE
Staging

### DIFF
--- a/app/Http/Requests/Api/V1/Task/StoreTaskRequest.php
+++ b/app/Http/Requests/Api/V1/Task/StoreTaskRequest.php
@@ -29,7 +29,8 @@ class StoreTaskRequest extends FormRequest
             'due_date' => ['nullable', 'date', 'after_or_equal:today'],
             'is_completed' => ['required', 'boolean'],
             'category_id' => [
-                'required',
+                // 'required',
+                'nullable',
                 'integer',
                 Rule::exists('categories', 'id')
             ],

--- a/app/Http/Requests/Api/V1/Task/UpdateTaskRequest.php
+++ b/app/Http/Requests/Api/V1/Task/UpdateTaskRequest.php
@@ -30,7 +30,8 @@ class UpdateTaskRequest extends FormRequest
             'is_completed' => ['sometimes', 'boolean'],
             'category_id' => [
                 'sometimes',
-                'required',
+                // 'required',
+                'nullable',
                 'integer',
                 Rule::exists('categories', 'id'),
             ]

--- a/app/Http/Resources/Api/V1/Task/TaskResource.php
+++ b/app/Http/Resources/Api/V1/Task/TaskResource.php
@@ -22,9 +22,15 @@ class TaskResource extends JsonResource
             'due_date' => $this->due_date,
             'is_completed' => $this->is_completed,
             'user' => $this->user,
-            'category' => $this->whenLoaded('category', function () {
-                return new CategoryResource($this->category);
-            }),
+            // 'category' => $this->whenLoaded('category', function () {
+            //     return new CategoryResource($this->category);
+            // }),
+            'category' => $this->category ? new CategoryResource($this->category) : null,
+            'has_category' => $this->hasCategory(),
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+
+
         ];
     }
 }

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -28,7 +28,7 @@ class Task extends Model
 
     public function user(): BelongsTo
     {
-        return $this->belongsTo(User::class, 'user_id');
+        return  $this->belongsTo(User::class, 'user_id');
     }
 
     public function category(): BelongsTo
@@ -41,6 +41,8 @@ class Task extends Model
         return !is_null($this->category_id);
     }
 
+    // In the future, if nahan ko mu apply ug filter sa serve side
+    // but for now, leave it muna as is 
     public function scopeUncategorized($query)
     {
         return $query->whereNull('category_id');

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -35,4 +35,19 @@ class Task extends Model
     {
         return $this->belongsTo(Category::class, 'category_id');
     }
+
+    public function hasCategory(): Bool
+    {
+        return !is_null($this->category_id);
+    }
+
+    public function scopeUncategorized($query)
+    {
+        return $query->whereNull('category_id');
+    }
+
+    public function scopeCategorized($query)
+    {
+        return $query->whereNotNull('category_id');
+    }
 }

--- a/database/migrations/2025_08_23_120016_modify_tasks_category_foreign_key_into_null_on_delete.php
+++ b/database/migrations/2025_08_23_120016_modify_tasks_category_foreign_key_into_null_on_delete.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        //
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->dropForeign(['category_id']);
+
+            $table->foreignId('category_id')->nullable()->change();
+
+            $table->foreign('category_id')->references('id')->on('categories')->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+        Schema::table('tasks', function (Blueprint $table) {
+            // Drop the current foreign key
+            $table->dropForeign(['category_id']);
+
+            // Make category_id not nullable again
+            $table->foreignId('category_id')->nullable(false)->change();
+
+            // Restore the original cascade delete constraint
+            $table->foreign('category_id')->references('id')->on('categories')->cascadeOnDelete();
+        });
+    }
+};


### PR DESCRIPTION
This pull request updates how tasks are associated with categories, making the `category_id` field optional and handling cases where a task may not have a category. It includes changes to validation rules, resource serialization, model methods, and database constraints to support tasks without categories.

**Database changes:**

* Migration `2025_08_23_120016_modify_tasks_category_foreign_key_into_null_on_delete.php` updates the `tasks` table so that `category_id` is nullable and sets the foreign key to `null` when a category is deleted, instead of deleting the task. The down migration restores the previous behavior.

**Validation rule updates:**

* In both `StoreTaskRequest` and `UpdateTaskRequest`, the `category_id` field is now nullable instead of required, allowing tasks to be created or updated without a category. [[1]](diffhunk://#diff-7bbf677d67ddbbeae353b496ec52fea7a60cae26b8f3fcbdd8735880553f44ebL32-R33) [[2]](diffhunk://#diff-7674e19fdb81eec68717c4e7fa5aab642c01ce2110f1f6c013493663aa2325d2L33-R34)

**Resource and model improvements:**

* `TaskResource` now directly returns the category or `null` if absent, adds a `has_category` flag, and includes `created_at` and `updated_at` fields.
* The `Task` model adds a `hasCategory()` method and query scopes for categorized and uncategorized tasks.